### PR TITLE
💄 Fix confetti, make success bar more glowy.

### DIFF
--- a/frontend/src/components/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar.tsx
@@ -35,9 +35,10 @@ export default function ProgressBar({
     <div className="flex flex-col space-y-2">
       <h3 className="text-center">{title}</h3>
       <div
-        className={`w-full h-6 rounded-xl overflow-hidden ${
-          isComplete ? "shadow-md shadow-amber-200/30" : ""
-        }`}
+        className={clsx(
+          "w-full h-6 rounded-xl overflow-hidden",
+          isComplete && "gold-glow"
+        )}
         style={{
           backgroundColor: remainingColor,
         }}

--- a/frontend/src/components/SortableProgressBar.tsx
+++ b/frontend/src/components/SortableProgressBar.tsx
@@ -28,12 +28,12 @@ export default function SortableProgressBar({
   onDecrement,
   className = "",
 }: SortableProgressBarProps) {
-  const [showConfetti, setShowConfetti] = useState(false);
   const [isComplete, setIsComplete] = useState(bar.current === bar.max);
   const [isHovered, setIsHovered] = useState(false);
   const [hoverSide, setHoverSide] = useState<"left" | "right" | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [showConfetti, setShowConfetti] = useState(false);
 
   const {
     attributes,
@@ -54,8 +54,11 @@ export default function SortableProgressBar({
     if (bar.current === bar.max) {
       setIsComplete(true);
       setShowConfetti(true);
-    } else if (isComplete) {
-      setIsComplete(false);
+    } else {
+      if (isComplete) {
+        setIsComplete(false);
+      }
+      setShowConfetti(false);
     }
   }, [bar.current, bar.max, isComplete]);
 
@@ -83,8 +86,12 @@ export default function SortableProgressBar({
     zIndex: isDragging ? 10 : 0,
     position: "relative",
     touchAction: "none",
-    "--bar-increment-hover": bar.incrementHoverGlowHex ?? "#84cc16",
-    "--bar-decrement-hover": bar.decrementHoverGlowHex ?? "#ea580c",
+    "--bar-increment-hover": isComplete
+      ? "#FFD700"
+      : (bar.incrementHoverGlowHex ?? "#84cc16"),
+    "--bar-decrement-hover": isComplete
+      ? "#FFD700"
+      : (bar.decrementHoverGlowHex ?? "#ea580c"),
   };
 
   const content = (
@@ -93,9 +100,9 @@ export default function SortableProgressBar({
       style={style}
       className={clsx(
         "flex items-center rounded-lg p-4",
-        isComplete && "golden-pattern completed",
         isHovered && hoverSide === "right" && "bar-hover-right",
         isHovered && hoverSide === "left" && "bar-hover-left",
+        isComplete && "completed",
         className
       )}
       onContextMenu={onContextMenu}
@@ -128,7 +135,9 @@ export default function SortableProgressBar({
     </div>
   );
 
-  if (!showConfetti) return content;
+  if (!showConfetti) {
+    return content;
+  }
 
   return (
     <div ref={containerRef} className="relative w-full">
@@ -139,16 +148,16 @@ export default function SortableProgressBar({
         recycle={true}
         numberOfPieces={30}
         colors={["#FFD700", "#FFC000", "#FFA500"]}
-        gravity={0.05}
-        initialVelocityY={0.05}
+        gravity={0.15}
+        initialVelocityY={1.5}
         confettiSource={{
           w: containerRef.current?.offsetWidth || 0,
-          h: containerRef.current?.offsetHeight || 0,
+          h: 1,
           x: 0,
           y: 0,
         }}
         className="absolute inset-0"
-        style={{ pointerEvents: "none", zIndex: 20 }}
+        style={{ pointerEvents: "none", zIndex: 30 }}
       />
       {content}
     </div>

--- a/frontend/src/components/SuccessModal.tsx
+++ b/frontend/src/components/SuccessModal.tsx
@@ -3,6 +3,7 @@ import type { ProgressBarData } from "../../../types/shared";
 import { Button } from "./Button";
 import ReactConfetti from "react-confetti";
 import { getSoundManager } from "../sound/soundManager";
+import { useEffect, useState } from "react";
 
 interface SuccessModalProps {
   barData: ProgressBarData;
@@ -22,11 +23,38 @@ export function SuccessModal({
     onRequestClose();
   };
 
+  // Track window size to keep confetti canvas in sync with resizes.
+  const [windowSize, setWindowSize] = useState<{
+    width: number;
+    height: number;
+  }>(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }));
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize({ width: window.innerWidth, height: window.innerHeight });
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
   // TODO: Add custom uplifting dismiss messages + congratulations messages.
   // TODO: Add completion stats? Completed after x days. Created on...
   // TODO: Add the golden experience mission success soundbite (it was a minified, slightly muted version of the main theme).
   return (
-    <ReactConfetti className="flex flex-col">
+    <>
+      <ReactConfetti
+        width={windowSize.width}
+        height={windowSize.height}
+        recycle={true}
+        run={isOpen}
+        className="confetti-overlay"
+      />
       <Modal
         isOpen={isOpen}
         ariaHideApp={false}
@@ -47,6 +75,6 @@ export function SuccessModal({
           {"Good job, champ!"}
         </Button>
       </Modal>
-    </ReactConfetti>
+    </>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -56,6 +56,22 @@
     animation: shine 2s linear infinite;
   }
 
+  /* Strong golden glow utility for completed bars */
+  .gold-glow {
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, #ffd700 35%, transparent) inset,
+      0 0 18px 4px color-mix(in srgb, #ffd700 55%, transparent),
+      0 0 45px 12px color-mix(in srgb, #ffc000 35%, transparent);
+    transition: box-shadow 150ms linear;
+  }
+
+  .confetti-overlay {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 45;
+  }
+
   ::-webkit-scrollbar {
     width: 6px;
     height: 6px;


### PR DESCRIPTION
- Success modal confetti should take up the whole screen now, even after successive window resizes.
- SortableProgressBar confetti should disappear now when decrementing from full.